### PR TITLE
feat: switch to github actions; fix tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      DB_CONNECTION_STRING: "sqlite:///:memory:"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Type check with mypy
+      run: |
+        mypy *.py
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - 3.6
-install:
-  - pip install -r requirements.txt
-script: mypy *.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argon2-cffi==20.1.0
 cffi==1.14.4
 Click==7.1.2
-dnspython==2.1.0
+dnspython==1.16.0
 eventlet==0.30.0
 ffmpeg-python==0.2.0
 Flask==1.1.2


### PR DESCRIPTION
This switches to Github actions to permit better handling of dependency upgrades (Travis has disconnected this repo multiple times, so...) The github actions part is mostly boilerplate from Github themselves, with the addition of `mypy` type checking.

This additionally fixes the install and tests by downgrading `dnspython` (for which `eventlet` does not support the latest version) and removing an errant `__init__.py` (this isn't a library.)